### PR TITLE
Use postman-collection to parse the URL

### DIFF
--- a/script.js
+++ b/script.js
@@ -148,11 +148,15 @@ class SignatureFactory {
  * This is code to init the auth and date header
  */
 
-url = new URL(request.url)
+var sdk = require('postman-collection'),
+    url = new sdk.Url(request.url),
+    hostname = url.getHost(),
+    pathname = url.getPath(),
+    queryString = url.getQueryString();
 
-sf = new SignatureFactory(postman.getEnvironmentVariable("access_key"), postman.getEnvironmentVariable("secret_key"), url.hostname);
-sf.setUrl(url.pathname);
-sf.setQueryParameters(url.search.substring(1));
+sf = new SignatureFactory(postman.getEnvironmentVariable("access_key"), postman.getEnvironmentVariable("secret_key"), hostname);
+sf.setUrl(pathname);
+sf.setQueryParameters(queryString);
 
 postman.setGlobalVariable('ub_header_auth', sf.authHeader());
 postman.setGlobalVariable('ub_header_date', sf.dates.longdate);


### PR DESCRIPTION
In newer versions of Postman, the URL library built into Chrome is not available. The recommended solution is to use Postman's built-in postman-collection module (see https://github.com/postmanlabs/postman-app-support/issues/3059).

I don't have Chrome version to test this on, but if it breaks we can add a condition to check if `URL` library is present first.